### PR TITLE
check that inline images is not empty

### DIFF
--- a/mail_merge.js
+++ b/mail_merge.js
@@ -37,10 +37,12 @@ function getInlineImg(message){
 function cidExtract(body){
   var cids = [];
   var inlineImages = body.match(/<img [^>]*src="[^"]*"[^>]*>/gm);
-  inlineImages.forEach(function(img) {
-        x = img.match(/src="cid:([^"]*)"/);
-        cids.push(x[1]);
-  });
+  if (inlineImages) {
+    inlineImages.forEach(function(img) {
+          x = img.match(/src="cid:([^"]*)"/);
+          cids.push(x[1]);
+    });
+  }
   return cids;
 }
 


### PR DESCRIPTION
If there is no inline image in the draft email, the forEach will cause an error